### PR TITLE
[Fix]: Connections using deprecated methods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
 	dependencies:[
 		.package(
 			url:"https://github.com/simplito/privmx-endpoint-swift",
-			branch: "dev"
+			.upToNextMinor(from:.init(2, 1, 0,prereleaseIdentifiers: ["rc1"]))
 		),
 	],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
 	dependencies:[
 		.package(
 			url:"https://github.com/simplito/privmx-endpoint-swift",
-			.upToNextMinor(from:.init(2, 1, 0,prereleaseIdentifiers: ["rc1"]))
+			branch: "dev"
 		),
 	],
     targets: [

--- a/Sources/PrivMXEndpointSwiftExtra/Core/Connection.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/Connection.swift
@@ -54,7 +54,7 @@ extension Connection: PrivMXConnection {
 		try Self.connect(
 			userPrivKey: std.string(userPrivKey),
 			solutionId: std.string(solutionID),
-			platformUrl: std.string(bridgeUrl))
+			bridgeUrl: std.string(bridgeUrl))
 	}
 
 	/// Establishes a public connection to PrivMX Bridge.
@@ -74,7 +74,7 @@ extension Connection: PrivMXConnection {
 	) throws -> any PrivMXConnection {
 		try Self.connectPublic(
 			solutionId: std.string(solutionID),
-			platformUrl: std.string(bridgeUrl))
+			bridgeUrl: std.string(bridgeUrl))
 	}
 
 	/// Sets the path to the `.pem` file containing certificates required for establishing a connection.

--- a/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpoint.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpoint.swift
@@ -45,7 +45,8 @@ public class PrivMXEndpoint: Identifiable{
     ///   - platformUrl: The URL of PrivMX Bridge instance.
     ///
     /// - Throws: An error if the connection or module initialization fails.
-    public init(
+	@available(*, deprecated)
+	public init(
 		modules:Set<PrivMXModule>,
 		userPrivKey:String,
 		solutionId:String,
@@ -54,6 +55,48 @@ public class PrivMXEndpoint: Identifiable{
 		var con = try Connection.connect(userPrivKey: std.string(userPrivKey),
 										 solutionId: std.string(solutionId),
 										 platformUrl: std.string(platformUrl))
+		self.connection = con
+		self.anonymous = false
+		var thr:ThreadApi?
+		var sto:StoreApi?
+		if modules.contains(.thread){
+			thr = try ThreadApi.create(connection: &con)
+			self.threadApi = thr
+		}
+		if modules.contains(.store){
+			sto = try StoreApi.create(connection: &con)
+			self.storeApi = sto
+		}
+		if modules.contains(.inbox){
+			var s = try (sto ?? StoreApi.create(connection: &con))
+			var t = try (thr ?? ThreadApi.create(connection: &con))
+			self.inboxApi = try InboxApi.create(connection: &con,
+												  threadApi: &t,
+												  storeApi: &s)
+		}
+		self.id = try! con.getConnectionId()
+	}
+	
+	/// Initializes a new instance of `PrivMXEndpoint` with a connection to PrivMX Bridge and optional modules.
+    ///
+    /// This method sets up the connection and, based on the provided modules, initializes the APIs for handling Threads, Stores, and Inboxes.
+    ///
+    /// - Parameters:
+    ///   - modules: A set of modules to initialize (of type `PrivMXModule`).
+    ///   - userPrivKey: The user's private key in WIF format.
+    ///   - solutionId: The unique identifier of PrivMX Solution.
+    ///   - bridgeUrl: The URL of PrivMX Bridge instance.
+    ///
+    /// - Throws: An error if the connection or module initialization fails.
+	public init(
+		modules:Set<PrivMXModule>,
+		userPrivKey:String,
+		solutionId:String,
+		bridgeUrl:String
+	) throws {
+		var con = try Connection.connect(userPrivKey: std.string(userPrivKey),
+										 solutionId: std.string(solutionId),
+										 bridgeUrl: std.string(bridgeUrl))
 		self.connection = con
 		self.anonymous = false
 		var thr:ThreadApi?
@@ -87,6 +130,7 @@ public class PrivMXEndpoint: Identifiable{
 	///   - platformUrl: The URL of the PrivMX Bridge instance.
 	///
 	/// - Throws: An error if the connection or module initialization fails.
+	@available(*, deprecated)
 	public init(
 		modules:Set<PrivMXModule>,
 		solutionId:String,
@@ -94,6 +138,46 @@ public class PrivMXEndpoint: Identifiable{
 	) throws {
 		var con = try Connection.connectPublic(solutionId: std.string(solutionId),
 											   platformUrl: std.string(platformUrl))
+		self.connection = con
+		self.anonymous = true
+		var thr:ThreadApi?
+		var sto:StoreApi?
+		if modules.contains(.thread){
+			thr = try ThreadApi.create(connection: &con)
+			self.threadApi = thr
+		}
+		if modules.contains(.store){
+			sto = try StoreApi.create(connection: &con)
+			self.storeApi = sto
+		}
+		if modules.contains(.inbox){
+			var s = try (sto ?? StoreApi.create(connection: &con))
+			var t = try (thr ?? ThreadApi.create(connection: &con))
+			self.inboxApi = try InboxApi.create(connection: &con,
+												  threadApi: &t,
+												  storeApi: &s)
+		}
+		self.id = try! con.getConnectionId()
+	}
+	
+	/// Initializes a new instance of `PrivMXEndpoint` with a public connection to the PrivMX Bridge and optional modules.
+	///
+	/// This method sets up the connection and, based on the provided modules, initializes the APIs for handling threads, stores, and inboxes. Using a Public (anonymous) connection.
+	/// Take note that this is only useful for Inboxes
+	///
+	/// - Parameters:
+	///   - modules: A set of modules to initialize (of type `PrivMXModule`).
+	///   - solutionId: The unique identifier of the PrivMX solution.
+	///   - bridgeUrl: The URL of the PrivMX Bridge instance.
+	///
+	/// - Throws: An error if the connection or module initialization fails.
+	public init(
+		modules:Set<PrivMXModule>,
+		solutionId:String,
+		bridgeUrl:String
+	) throws {
+		var con = try Connection.connectPublic(solutionId: std.string(solutionId),
+											   bridgeUrl: std.string(bridgeUrl))
 		self.connection = con
 		self.anonymous = true
 		var thr:ThreadApi?

--- a/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpointContainer.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpointContainer.swift
@@ -63,7 +63,7 @@ public class PrivMXEndpointContainer{
 	///   - modules: A set of modules to be initialized with the new endpoint.
 	///   - userPrivKey: The user's private key in WIF format.
 	///   - solutionId: The unique identifier of PrivMX solution.
-	///   - platformUrl: The URL of PrivMX Bridge.
+	///   - bridgeUrl: The URL of PrivMX Bridge.
 	///
 	/// - Throws: An error if creating the new endpoint fails.
 	///
@@ -72,12 +72,12 @@ public class PrivMXEndpointContainer{
 		enabling modules:Set<PrivMXModule>,
 		connectingAs userPrivKey:String,
 		to solutionId:String,
-		on platformUrl:String
+		on bridgeUrl:String
 	) async throws -> PrivMXEndpoint {
 		let ne = try PrivMXEndpoint(modules: modules,
 									   userPrivKey: userPrivKey,
 									   solutionId: solutionId,
-									   platformUrl: platformUrl)
+									   bridgeUrl: bridgeUrl)
 		endpoints[try ne.connection.getConnectionId()] = ne
 		return ne
 	}
@@ -92,7 +92,7 @@ public class PrivMXEndpointContainer{
 	///   - modules: A set of modules to be initialized with the new endpoint.
 	///   - userPrivKey: The user's private key in WIF format.
 	///   - solutionId: The unique identifier of the PrivMX solution.
-	///   - platformUrl: The URL of the PrivMX Bridge.
+	///   - bridgeUrl: The URL of the PrivMX Bridge.
 	///
 	/// - Throws: An error if creating the new endpoint fails.
 	///
@@ -100,11 +100,11 @@ public class PrivMXEndpointContainer{
 	public func newPublicEndpoint(
 		enabling modules:Set<PrivMXModule>,
 		to solutionId:String,
-		on platformUrl:String
+		on bridgeUrl:String
 	) async throws -> PrivMXEndpoint {
 		let ne = try PrivMXEndpoint(modules: modules,
 									solutionId: solutionId,
-									platformUrl: platformUrl)
+									bridgeUrl: bridgeUrl)
 		endpoints[try ne.connection.getConnectionId()] = ne
 		return ne
 	}

--- a/Sources/PrivMXEndpointSwiftExtra/Types/UserWithPubKey.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Types/UserWithPubKey.swift
@@ -1,0 +1,22 @@
+//
+// PrivMX Endpoint Swift Extra
+// Copyright © 2024 Simplito sp. z o.o.
+//
+// This file is part of the PrivMX Platform (https://privmx.dev).
+// This software is Licensed under the MIT License.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import PrivMXEndpointSwiftNative
+
+public extension privmx.endpoint.core.UserWithPubKey{
+	init(
+		userId: String,
+		pubKey: String
+	){
+		self.init(userId: std.string(userId),
+				  pubKey: std.string(pubKey))
+	}
+}


### PR DESCRIPTION
- Fixed Endpoint and EndpointContainer still using deprecated methods
- Connection PrivMXConnection conformance using

See: simplito/privmx-endpoint-swift#5,