### PR TITLE
Feat!: updateFileMeta

### DIFF
--- a/Sources/PrivMXEndpointSwiftExtra/Stores/PrivMXStore.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Stores/PrivMXStore.swift
@@ -185,6 +185,18 @@ public protocol PrivMXStore{
 		replacingSize size: Int64
 	) throws -> privmx.StoreFileHandle
 	
+	/// Updates an existing File by overwriting its metadata.
+	///
+	/// - Parameters:
+	///   - fileId: The unique identifier of the File to be updated.
+	///   - publicMeta: New public metadata for the File, which will be unencrypted.
+	///   - privateMeta: New private metadata for the File, which will be encrypted.
+	func updateFileMeta(
+		of fileId: String,
+		replacingPublicMeta publicMeta: Data,
+		replacingPrivateMeta privateMeta: Data
+	) throws -> Void
+	
 	/// Opens a File for reading and returns a file handle (`StoreFileHandle`).
 	///
 	/// This method opens an existing File, identified by its file ID, and returns a handle that can be used

--- a/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
@@ -115,6 +115,16 @@ extension StoreApi : PrivMXStore{
 					   size: size)
 	}
 	
+public func updateFileMeta(
+		of fileId: String,
+		replacingPublicMeta publicMeta: Data,
+		replacingPrivateMeta privateMeta: Data
+	) throws -> privmx.StoreFileHandle {
+		try updateFileMeta(fileId:std.string(fileId),
+						   publicMeta: publicMeta.asBuffer(),
+						   privateMeta: privateMeta.asBuffer())
+	}
+	
 	
 	public func openFile(
 		_ fileId: String

--- a/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
@@ -115,7 +115,7 @@ extension StoreApi : PrivMXStore{
 					   size: size)
 	}
 	
-public func updateFileMeta(
+	public func updateFileMeta(
 		of fileId: String,
 		replacingPublicMeta publicMeta: Data,
 		replacingPrivateMeta privateMeta: Data

--- a/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
@@ -119,7 +119,7 @@ extension StoreApi : PrivMXStore{
 		of fileId: String,
 		replacingPublicMeta publicMeta: Data,
 		replacingPrivateMeta privateMeta: Data
-	) throws -> privmx.StoreFileHandle {
+	) throws -> Void {
 		try updateFileMeta(fileId:std.string(fileId),
 						   publicMeta: publicMeta.asBuffer(),
 						   privateMeta: privateMeta.asBuffer())


### PR DESCRIPTION
Requires simplito/privmx-endpoint-swift#12

## Additions:
- `updateFiileMeta` method in `StoreApi`
- `updateFiileMeta` method in `PrivMXStore` (This is a breaking change, since it modifies a protocol that someone might have conformed to)