### PR TITLE
Policy and & or methods hotfix

### DIFF
--- a/Sources/PrivMXEndpointSwiftExtra/Core/ContainerPolicyValue.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/ContainerPolicyValue.swift
@@ -53,10 +53,10 @@ public enum ContainerPolicyValue: RawRepresentable{
 						flag = true
 					}
 					else{
-						cas.and(c)
+						cas.andMutating(c)
 					}
 				}
-				self.or(cas)
+				self.orMutating(cas)
 			}
 		} else {
 			switch rawValue{
@@ -106,7 +106,7 @@ public enum ContainerPolicyValue: RawRepresentable{
 	///
 	/// - Returns: modified `self`.
 	@discardableResult
-	public mutating func and(
+	public mutating func andMutating(
 		_ val:ContainerPolicyValue
 	) -> ContainerPolicyValue{
 		self = .complex("\(self.rawValue)&\(val.rawValue)")
@@ -118,10 +118,31 @@ public enum ContainerPolicyValue: RawRepresentable{
 	/// - Parameter val: Policy value to be appended with "OR" operator
 	/// - Returns: modified `self`
 	@discardableResult
-	public mutating func or(
+	public mutating func orMutating(
 		_ val:ContainerPolicyValue
 	) -> ContainerPolicyValue{
 		self = .complex("\(self.rawValue),\(val.rawValue)")
 		return self
 	}
+	
+	/// Creates a new `ContainerPolicyValue.complex` with the the associated value consisting of `self.rawValue` and `val.rawValue`connected with `&`.
+	///
+	/// - Parameter val: Policy value to be appended with "AND" operator
+	/// - Returns: new `.complex` `ContainerPolicyValue`
+	public func and(
+		_ val:ContainerPolicyValue
+	) -> ContainerPolicyValue{
+		.complex("\(self.rawValue)&\(val.rawValue)")
+	}
+	
+	/// Creates a new `ContainerPolicyValue.complex` with the the associated value consisting of `self.rawValue` and `val.rawValue`connected with `&`
+	///
+	/// - Parameter val: Policy value to be appended with "OR" operator
+	/// - Returns: modified `self`
+	public func or(
+		_ val:ContainerPolicyValue
+	) -> ContainerPolicyValue{
+		.complex("\(self.rawValue),\(val.rawValue)")
+	}
+
 }

--- a/Sources/PrivMXEndpointSwiftExtra/Core/ItemPolicyValue.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/ItemPolicyValue.swift
@@ -53,14 +53,14 @@ public enum ItemPolicyValue: RawRepresentable, Equatable{
 						flag = true
 					}
 					else{
-						cas.and(c)
+						cas.andMutating(c)
 					}
 				}
 				if !flag{
 					self = cas
 					flag = true
 				}else{
-					self.or(cas)
+					self.orMutating(cas)
 				}
 			}
 		} else {
@@ -111,7 +111,7 @@ public enum ItemPolicyValue: RawRepresentable, Equatable{
 	/// - Parameter val: Policy value to be appended with "AND" operator
 	/// - Returns: modified `self`
 	@discardableResult
-	public mutating func and(
+	public mutating func andMutating(
 		_ val:ItemPolicyValue
 	) -> ItemPolicyValue{
 		self = .complex("\(self.rawValue)&\(val.rawValue)")
@@ -123,10 +123,30 @@ public enum ItemPolicyValue: RawRepresentable, Equatable{
 	/// - Parameter val: Policy value to be appended with "OR" operator
 	/// - Returns: modified `self`
 	@discardableResult
-	public mutating func or(
+	public mutating func orMutating(
 		_ val:ItemPolicyValue
 	) -> ItemPolicyValue{
 		self = .complex("\(self.rawValue),\(val.rawValue)")
 		return self
+	}
+	
+	/// Creates a new `ItemPolicyValue.complex` with the the associated value consisting of `self.rawValue` and `val.rawValue`connected with `&`.
+	///
+	/// - Parameter val: Policy value to be appended with "AND" operator
+	/// - Returns: new `.complex` `ItemPolicyValue`
+	public func and(
+		_ val:ItemPolicyValue
+	) -> ItemPolicyValue{
+		.complex("\(self.rawValue)&\(val.rawValue)")
+	}
+	
+	/// Creates a new `ItemPolicyValue.complex` with the the associated value consisting of `self.rawValue` and `val.rawValue`connected with `&`
+	///
+	/// - Parameter val: Policy value to be appended with "OR" operator
+	/// - Returns: modified `self`
+	public func or(
+		_ val:ItemPolicyValue
+	) -> ItemPolicyValue{
+		.complex("\(self.rawValue),\(val.rawValue)")
 	}
 }


### PR DESCRIPTION
Changed `.and(_:)` and `.or(_:)` to be non-mutating (returning new `ItemPolicyValue`/`ContainerPolicyValue` objects)
Added `.andMutaing(_:)` and `.orMutating(_:)` to ItemPolicyValue and `ContainerPolicyValue`