### PR TITLE
Feat(crypto): fix verifySignature method

### DIFF
--- a/Sources/PrivMXEndpointSwiftExtra/Crypto/CryptoApi.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Crypto/CryptoApi.swift
@@ -86,21 +86,24 @@ extension CryptoApi: PrivMXCrypto{
 		try String(self.convertPEMKeyToWIFKey(pemKey:std.string(pemKey)))
 	}
 	
-	/// Validate a signature of data using given key.
-	///
-	/// - Parameter data: buffer containing the data signature of which is being verified.
-	/// - Parameter signature: signature to be verified.
-	/// - Parameter publicKey: public ECC key in BASE58DER format used to validate data.
-	/// - Returns: data validation result.
-	///
-	/// - Throws: `PrivMXEndpointError.failedVerifyingSignature` if an verification process fails.
+	@available(*, deprecated)
 	public func verifySignature(
 		data: Data,
 		signature: Data,
 		publicKey: String
 	) throws -> Bool {
 		try self.verifySignature(data: data.asBuffer(),
-								 signature: data.asBuffer(),
+								 signature: signature.asBuffer(),
+								 publicKey: std.string(publicKey))
+	}
+	
+	public func verifySignature(
+		_ signature: Data,
+		of data: Data,
+		with publicKey: String
+	) throws -> Bool {
+		try self.verifySignature(data: data.asBuffer(),
+								 signature: signature.asBuffer(),
 								 publicKey: std.string(publicKey))
 	}
 }

--- a/Sources/PrivMXEndpointSwiftExtra/Crypto/PrivMXCrypto.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Crypto/PrivMXCrypto.swift
@@ -153,16 +153,16 @@ public protocol PrivMXCrypto{
 	
 	/// Validate a signature of data using given key.
 	///
-	/// - Parameter data: buffer containing the data signature of which is being verified.
 	/// - Parameter signature: signature to be verified.
+	/// - Parameter data: buffer containing the data signature of which is being verified.
 	/// - Parameter publicKey: public ECC key in BASE58DER format used to validate data.
 	/// - Returns: data validation result.
 	///
 	/// - Throws: `PrivMXEndpointError.failedVerifyingSignature` if an verification process fails.
 	func verifySignature(
-		data: Data,
-		signature: Data,
-		publicKey: String
+		_ signature: Data,
+		of data: Data,
+		with publicKey: String
 	) throws -> Bool
 }
 


### PR DESCRIPTION
Fixed improper behaviour of verifySignature method

## Additions:
- Added `verifySignature(_:of:with:)` to CryptoApi

## Modifications:
- deprecated `verifySignature(signature:data:publicKey:)` (that took `Data` and `String`)