### PR TITLE
Feat(store): Fixed typo in method for unsubscribing from File events 

### DIFF
--- a/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpoint.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpoint.swift
@@ -734,7 +734,7 @@ public class PrivMXEndpoint: Identifiable{
 				if s == "thread"{
 					try threadApi?.unsubscribeFromMessageEvents(in: id)
 				}else if s == "store"{
-					try storeApi?.unubscribeFromFileEvents(in: id)
+					try storeApi?.unsubscribeFromFileEvents(in: id)
 				}else if s == "inbox"{
 					try inboxApi?.unsubscribeFromEntryEvents(in: id)
 				}

--- a/Sources/PrivMXEndpointSwiftExtra/Stores/PrivMXStore.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Stores/PrivMXStore.swift
@@ -317,8 +317,16 @@ public protocol PrivMXStore{
 	/// - Parameter storeId: The unique identifier of the Store for which to unsubscribe from file events.
 	///
 	/// - Throws: An error if the unsubscribing fails.
-	func unubscribeFromFileEvents(
+	func unsubscribeFromFileEvents(
 		in storeId:String
 	) throws -> Void
 }
 
+extension PrivMXStore{
+	@available(*, deprecated,renamed: "unsubscribeFromFileEvents(in:)")
+	public func unubscribeFromFileEvents(
+		in storeId: String
+	) throws -> Void {
+		try self.unsubscribeFromFileEvents(in: storeId)
+	}
+}

--- a/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Stores/StoreApi.swift
@@ -196,7 +196,14 @@ extension StoreApi : PrivMXStore{
 					   position: position)
 	}
 	
+	@available(*, deprecated, renamed: "unsubscribeFromFileEvents(in:)")
 	public func unubscribeFromFileEvents(
+		in storeId: String
+	) throws -> Void {
+		try unsubscribeFromFileEvents(storeId: std.string(storeId))
+	}
+	
+	public func unsubscribeFromFileEvents(
 		in storeId: String
 	) throws -> Void {
 		try unsubscribeFromFileEvents(storeId: std.string(storeId))


### PR DESCRIPTION
## Additions:
- `unsubscribeFromFileEvents(in:)` method in `PrivMXStore`
- a deprecated `unubscribeFromFileEvents(in:)` method in extension of `PrivMXStore` calling the correctly named requirement

## Modifications
- Deprecated `unubscirbeFromFileEvents(in:)` in StoreApi

## Deletions:
- `unubscribeFromFileEvents(in:)` from PrivMXStore requirements