### PR TITLE
Feat!: Implemented listConextUsers(of:basedOn:)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
 	],
 	dependencies:[
 		.package(url:"https://github.com/simplito/privmx-endpoint-swift",
-				 .upToNextMinor(from: .init(2, 6, 0,prereleaseIdentifiers: ["rc1"]))
+				 .upToNextMinor(from: .init(2, 6, 0,prereleaseIdentifiers: ["rc2"]))
 				 ),
 	],
     targets: [

--- a/Sources/PrivMXEndpointSwiftExtra/Core/Connection.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/Connection.swift
@@ -103,8 +103,11 @@ extension Connection: PrivMXConnection {
 	///
 	/// - returns: a list of UserInfo objects.
 	public func getContextUsers(
-		of contextId: String
-	) throws -> [privmx.endpoint.core.UserInfo] {
-		try self.getContextUsers(contextId:std.string(contextId)).map({ x in x})
+		of contextId: String,
+		basedOn query: privmx.endpoint.core.PagingQuery
+	) throws -> privmx.UserInfoList {
+		try self.getContextUsers(
+			contextId:std.string(contextId),
+			query:query)
 	}
 }

--- a/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXConnection.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXConnection.swift
@@ -96,12 +96,13 @@ public protocol PrivMXConnection{
 	/// Retrieves a list of Users from a particular Context.
 	///
 	/// - parameter contextId: Id of the Context.
-	///
+	/// - parameter query:
 	/// - throws: When the operation fails.
 	///
-	/// - returns: a list of UserInfo objects.
+	/// - returns: a `PagingList` of UserInfo objects.
 	func getContextUsers(
-		of contextId: String
-	) throws -> [privmx.endpoint.core.UserInfo]
+		of contextId: String,
+		basedOn query: privmx.endpoint.core.PagingQuery
+	) throws -> privmx.UserInfoList
 }
 

--- a/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpoint.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/PrivMXEndpoint.swift
@@ -13,6 +13,7 @@ import Foundation
 import PrivMXEndpointSwiftNative
 import PrivMXEndpointSwift
 
+
 /// A wrapper class that manages a connection to PrivMX Bridge and provides access to various APIs, including Threads, Stores, and Inboxes.
 ///
 /// The `PrivMXEndpoint` class is designed to encapsulate and manage a single connection to PrivMX. It provides


### PR DESCRIPTION
Replaced `getContextUsers(of:) throws -> [privmx.endpoint.core.UserInfo]` 
 with `listContextUsers(of:basedOn:) throws -> privmx.UserInfoList`