### PR TITLE
Fix: kvdbEntry event registration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
 	],
 	dependencies:[
 		.package(url:"https://github.com/simplito/privmx-endpoint-swift",
-				 .upToNextMinor(from: .init(2, 6, 0,prereleaseIdentifiers: ["rc4"]))
+				 .upToNextMinor(from: .init(2, 6, 0))
 				 ),
 	],
     targets: [

--- a/Sources/PrivMXEndpointSwiftExtra/Core/PMXEventCallbackRegistration.swift
+++ b/Sources/PrivMXEndpointSwiftExtra/Core/PMXEventCallbackRegistration.swift
@@ -156,7 +156,7 @@ public enum PMXEventSubscriptionRequest: Hashable, Sendable{
 	case store(eventType: privmx.endpoint.store.EventType,selectorType: PMXEventSelectorType, selectorId:String)
 	/// Inbox module Events on a corresponding selector
 	case inbox(eventType: privmx.endpoint.inbox.EventType,selectorType: PMXEventSelectorType, selectorId:String)
-	/// Events from the KVDB module on a corresponding selector
+	/// Events from the KVDB module on a corresponding selector. This request accepts only `Context` and `Container` selectors.
 	case kvdb(eventType: privmx.endpoint.kvdb.EventType,selectorType: PMXEventSelectorType, selectorId:String)
 	/// Events about particualr KVDB Entry
 	case kvdbEntry(eventType: privmx.endpoint.kvdb.EventType, kvdbId:String,entryKey:String)


### PR DESCRIPTION
- Documentation update to mention the correct Selectors for PMXEventSubscriptionRequest.kvdb
- passing .Item to .kvdb Event subscription now correctly throws
- .kvdbEntry now correctly registers for events for particular entries